### PR TITLE
[FT] Add dashboard to present deactivated users

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-eslint": "^3.0.1"
   },
   "dependencies": {
+    "bootstrap": "^3.3.5",
     "bower": "^1.8.4"
   }
 }

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -1,54 +1,84 @@
 {% load i18n staticfiles %}
 
 <link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
+<link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
 <script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}" ></script>
 <script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}" ></script>
 <script>
 $(document).ready( function () {
     /* Make table sortable */
-    $('#main_member_list').DataTable({
+    $('#active_member_list, #inactive_member_list').DataTable({
         paging: false,
         bFilter: true,
         bInfo : false
     });
 });
 </script>
+<script>
+    function openTab(evt, tabName) {
+      var i, x, tablinks;
+      x = document.getElementsByClassName("tab");
+      for (i = 0; i < x.length; i++) {
+         x[i].style.display = "none";
+      }
+      tablinks = document.getElementsByClassName("tablink");
+      for (i = 0; i < x.length; i++) {
+         tablinks[i].className = tablinks[i].className.replace(" w3-border-red", "");
+      }
+      document.getElementById(tabName).style.display = "block";
+      evt.currentTarget.firstElementChild.className += " w3-border-red";
+    }
+</script>
 
-<table class="table table-hover" id="main_member_list">
-<thead>
-<tr>
-    {% for key in user_table.keys %}
-        <th>{{ key }}</th>
-    {% endfor %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
-        {% endif %}
-    </td>
-    {% endif %}
-</tr>
-{% endfor %}
-</tbody>
-</table>
+<div class="w3-container">
+  <h2>Members List</h2>
+
+  <div class="w3-row">
+    <a href="javascript:void(0)" class="active" onclick="openTab(event, 'Active');">
+      <div class="w3-third tablink w3-bottombar w3-hover-light-grey w3-padding w3-border-red">Active Users</div>
+    </a>
+    <a href="javascript:void(0)" onclick="openTab(event, 'Inactive');">
+      <div class="w3-third tablink w3-bottombar w3-hover-light-grey w3-padding">Inactive Users</div>
+    </a>
+  </div>
+
+  <div id="Active" class="w3-container tab">
+    <table class="table table-hover" id="active_member_list">
+        <thead>
+        <tr>
+            {% for key in user_table.keys %}
+                <th>{{ key }}</th>
+            {% endfor %}
+        </tr>
+        </thead>
+        <tbody>
+        {% for current_user in user_table.users %}
+            {% if current_user.obj.is_active == True %}
+                {% include "gym/user_table.html" %}
+            {% endif %}
+        {% endfor %}
+        </tbody>
+        </table>
+
+  </div>
+
+  <div id="Inactive" class="w3-container tab" style="display:none">
+    <table class="table table-hover" id="inactive_member_list">
+        <thead>
+            <tr>
+                {% for key in user_table.keys %}
+                    <th>{{ key }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for current_user in user_table.users %}
+                {% if current_user.obj.is_active == False %}
+                    {% include "gym/user_table.html" %}
+                {% endif %}
+            {% endfor %}
+        </tbody>
+    </table>
+  </div>        
+
+</div>

--- a/wger/gym/templates/gym/user_table.html
+++ b/wger/gym/templates/gym/user_table.html
@@ -1,0 +1,25 @@
+<tr>
+    <td>
+        {{current_user.obj.pk}}
+    </td>
+    <td>
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+    </td>
+    <td>
+        {{current_user.obj.get_full_name}}
+    </td>
+    <td data-order="{{current_user.last_log|date:'U'}}">
+        {{current_user.last_log|default:'-/-'}}
+    </td>
+    {% if show_gym %}
+    <td>
+        {% if current_user.obj.userprofile.gym_id %}
+            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+            {{ current_user.obj.userprofile.gym }}
+            </a>
+        {% else %}
+            -/-
+        {% endif %}
+    </td>
+    {% endif %}
+</tr>


### PR DESCRIPTION
#### Problem
-Initially, the only way to determine whether a gym member is active or not was to open his detail view. The list of users displayed both active and inactive users.

#### Solution
- I changed the gym members' display to a dashboard with 2 tabs, one for active users and another for inactive users
- The list for `Active Users` is displayed as the by default
- To view the inactive users, just click on the `Inactive Users` tab

#### Screenshots
- Here are screenshots of the new display
##### Active Users View
![Uploading Active Users.png…]()

##### Inactive Users View
![inactive users](https://user-images.githubusercontent.com/28805113/43511909-550ca02e-9582-11e8-907c-1dad2b8ab235.png)


[PT Card](https://www.pivotaltracker.com/story/show/159356753)