### PR TITLE
[FT] Add a new API endpoint to display all information about an exercise

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -25,6 +25,17 @@ from wger.exercises.models import (
 )
 
 
+class ExerciseInformationSerializer(serializers.ModelSerializer):
+    '''
+    Give detailed information about an exercise
+    '''
+    class Meta:
+        depth = 3
+        model = Exercise
+        fields = ('id', 'name', 'uuid','category', 'description', 'muscles',
+                  'muscles_secondary', 'equipment', 'language')
+
+
 class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -32,7 +32,8 @@ from wger.exercises.api.serializers import (
     ExerciseImageSerializer,
     ExerciseCategorySerializer,
     EquipmentSerializer,
-    ExerciseCommentSerializer
+    ExerciseCommentSerializer,
+    ExerciseInformationSerializer
 )
 from wger.exercises.models import (
     Exercise,
@@ -207,3 +208,8 @@ class MuscleViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = '__all__'
     filter_fields = ('name',
                      'is_front')
+
+
+class ExerciseInformationViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Exercise.objects.all()
+    serializer_class = ExerciseInformationSerializer

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -175,7 +175,7 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
 
     name = models.CharField(max_length=200,
                             verbose_name=_('Name'))
-    '''The exercise's name, with correct upercase'''
+    '''The exercise's name, with correct uppercase'''
 
     name_original = models.CharField(max_length=200,
                                      verbose_name=_('Name'),

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -84,29 +84,48 @@ v1_api.register(core_api.LicenseResource())
 router = routers.DefaultRouter()
 
 # Manager app
-router.register(r'workout', manager_api_views.WorkoutViewSet, base_name='workout')
-router.register(r'workoutsession', manager_api_views.WorkoutSessionViewSet, base_name='workoutsession')
-router.register(r'schedulestep', manager_api_views.ScheduleStepViewSet, base_name='schedulestep')
-router.register(r'schedule', manager_api_views.ScheduleViewSet, base_name='schedule')
+router.register(r'workout', manager_api_views.WorkoutViewSet,
+                base_name='workout')
+router.register(r'workoutsession', manager_api_views.WorkoutSessionViewSet,
+                base_name='workoutsession')
+router.register(r'schedulestep', manager_api_views.ScheduleStepViewSet,
+                base_name='schedulestep')
+router.register(r'schedule', manager_api_views.ScheduleViewSet,
+                base_name='schedule')
 router.register(r'day', manager_api_views.DayViewSet, base_name='day')
 router.register(r'set', manager_api_views.SetViewSet, base_name='Set')
-router.register(r'setting', manager_api_views.SettingViewSet, base_name='Setting')
-router.register(r'workoutlog', manager_api_views.WorkoutLogViewSet, base_name='workoutlog')
+router.register(r'setting', manager_api_views.SettingViewSet,
+                base_name='Setting')
+router.register(r'workoutlog', manager_api_views.WorkoutLogViewSet,
+                base_name='workoutlog')
 
 # Core app
-router.register(r'userprofile', core_api_views.UserProfileViewSet, base_name='userprofile')
-router.register(r'language', core_api_views.LanguageViewSet, base_name='language')
-router.register(r'daysofweek', core_api_views.DaysOfWeekViewSet, base_name='daysofweek')
-router.register(r'license', core_api_views.LicenseViewSet, base_name='license')
-router.register(r'setting-repetitionunit', core_api_views.RepetitionUnitViewSet, base_name='setting-repetition-unit')
-router.register(r'setting-weightunit', core_api_views.WeightUnitViewSet, base_name='setting-weight-unit')
+router.register(r'userprofile', core_api_views.UserProfileViewSet,
+                base_name='userprofile')
+router.register(r'language', core_api_views.LanguageViewSet,
+                base_name='language')
+router.register(r'daysofweek', core_api_views.DaysOfWeekViewSet,
+                base_name='daysofweek')
+router.register(r'license', core_api_views.LicenseViewSet,
+                base_name='license')
+router.register(r'setting-repetitionunit', core_api_views.RepetitionUnitViewSet,
+                base_name='setting-repetition-unit')
+router.register(r'setting-weightunit', core_api_views.WeightUnitViewSet,
+                base_name='setting-weight-unit')
 
 # Exercises app
-router.register(r'exercise', exercises_api_views.ExerciseViewSet, base_name='exercise')
-router.register(r'equipment', exercises_api_views.EquipmentViewSet, base_name='api')
-router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet, base_name='exercisecategory')
-router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet, base_name='exerciseimage')
-router.register(r'exercisecomment', exercises_api_views.ExerciseCommentViewSet, base_name='exercisecomment')
+router.register(r'exercise', exercises_api_views.ExerciseViewSet,
+                base_name='exercise')
+router.register(r'exerciseinfo', exercises_api_views.ExerciseInformationViewSet,
+                base_name='exerciseinfo')
+router.register(r'equipment', exercises_api_views.EquipmentViewSet,
+                base_name='api')
+router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet,
+                base_name='exercisecategory')
+router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet,
+                base_name='exerciseimage')
+router.register(r'exercisecomment', exercises_api_views.ExerciseCommentViewSet,
+                base_name='exercisecomment')
 router.register(r'muscle', exercises_api_views.MuscleViewSet, base_name='muscle')
 
 # Nutrition app

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -126,18 +126,26 @@ router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet,
                 base_name='exerciseimage')
 router.register(r'exercisecomment', exercises_api_views.ExerciseCommentViewSet,
                 base_name='exercisecomment')
-router.register(r'muscle', exercises_api_views.MuscleViewSet, base_name='muscle')
+router.register(r'muscle', exercises_api_views.MuscleViewSet,
+                base_name='muscle')
 
 # Nutrition app
-router.register(r'ingredient', nutrition_api_views.IngredientViewSet, base_name='api-ingredient')
-router.register(r'weightunit', nutrition_api_views.WeightUnitViewSet, base_name='weightunit')
-router.register(r'ingredientweightunit', nutrition_api_views.IngredientWeightUnitViewSet, base_name='ingredientweightunit')
-router.register(r'nutritionplan', nutrition_api_views.NutritionPlanViewSet, base_name='nutritionplan')
+router.register(r'ingredient', nutrition_api_views.IngredientViewSet,
+                base_name='api-ingredient')
+router.register(r'weightunit', nutrition_api_views.WeightUnitViewSet,
+                base_name='weightunit')
+router.register(r'ingredientweightunit',
+                nutrition_api_views.IngredientWeightUnitViewSet,
+                base_name='ingredientweightunit')
+router.register(r'nutritionplan', nutrition_api_views.NutritionPlanViewSet,
+                base_name='nutritionplan')
 router.register(r'meal', nutrition_api_views.MealViewSet, base_name='meal')
-router.register(r'mealitem', nutrition_api_views.MealItemViewSet, base_name='mealitem')
+router.register(r'mealitem', nutrition_api_views.MealItemViewSet,
+                base_name='mealitem')
 
 # Weight app
-router.register(r'weightentry', weight_api_views.WeightEntryViewSet, base_name='weightentry')
+router.register(r'weightentry', weight_api_views.WeightEntryViewSet,
+                base_name='weightentry')
 
 
 from django.contrib import admin
@@ -160,8 +168,10 @@ urlpatterns = i18n_patterns(
     url(r'exercise/', include('wger.exercises.urls', namespace='exercise')),
     url(r'weight/', include('wger.weight.urls', namespace='weight')),
     url(r'nutrition/', include('wger.nutrition.urls', namespace='nutrition')),
-    url(r'software/', include('wger.software.urls', namespace='software', app_name='software')),
-    url(r'config/', include('wger.config.urls', namespace='config', app_name='config')),
+    url(r'software/', include('wger.software.urls', namespace='software',
+                              app_name='software')),
+    url(r'config/', include('wger.config.urls', namespace='config',
+                            app_name='config')),
     url(r'gym/', include('wger.gym.urls', namespace='gym', app_name='gym')),
     url(r'email/', include('wger.email.urls', namespace='email')),
     url(r'^sitemap\.xml$',
@@ -177,8 +187,10 @@ urlpatterns += [
     url(r'^robots\.txt$',
         TextTemplateView.as_view(template_name="robots.txt"),
         name='robots'),
-    url(r'^manifest\.webapp$', WebappManifestView.as_view(template_name="manifest.webapp")),
-    url(r'^amazon-manifest\.webapp$', WebappManifestView.as_view(template_name="amazon-manifest.webapp")),
+    url(r'^manifest\.webapp$',
+        WebappManifestView.as_view(template_name="manifest.webapp")),
+    url(r'^amazon-manifest\.webapp$',
+        WebappManifestView.as_view(template_name="amazon-manifest.webapp")),
 
     # API
     url(r'^api/', include(v1_api.urls)),


### PR DESCRIPTION
### PROBLEM
- Currently there is no single API endpoint that gets all information about a specific exercise

### SOLUTION
- I added a new endpoint `/api/v2/exerciseinfo/` that gets all information about an exercise such as: _muscles information, secondary muscles information, equipment, category, description_ and returns to the client.
- This endpoint is only read-only. To create new exercises the client still has to use the old `api/v2/exercise/`

### SCREENSHOTS
![exercise_info](https://user-images.githubusercontent.com/28805113/43767836-a0bf9a38-9a3e-11e8-9f15-cb0b860ee742.png)
[PT Board Card](https://www.pivotaltracker.com/story/show/159356755)
