### PR TITLE
[FT:] Recieve an edit success message

### DIFF
--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -23,6 +23,7 @@ from django.contrib.auth.models import (
     Group,
     User
 )
+from django.contrib import messages
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.http.response import (
     HttpResponseForbidden,
@@ -272,6 +273,8 @@ def gym_permissions_user_edit(request, user_pk):
                 member.groups.add(Group.objects.get(
                     name='general_gym_manager'))
 
+            messages.success(request, _(
+                           'Successfully edited user roles.'))
             return HttpResponseRedirect(reverse('gym:gym:user-list',
                                                 kwargs={'pk': member.userprofile.gym.pk}))
     else:


### PR DESCRIPTION
**Problem**
The Manager does not recieve any communication that the action of changing user roles is successful.

**Solution**
The Manager should be able to receive a success message when they edit a user's role. This is done by setting a success message flag.

**Screenshot**
<img width="1241" alt="screen shot 2018-08-09 at 15 28 38" src="https://user-images.githubusercontent.com/17185082/43898895-f50406a0-9be8-11e8-910f-a959aef95985.png">
