### PR TITLE
Enable get exercises on mouse hover

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -43,7 +43,7 @@ $(document).ready(function() {
 
     // Init the autocompleter
     $('#exercise-search').autocomplete({
-        serviceUrl: '{% url 'exercise-search' %}',
+        serviceUrl: "{% url 'exercise-search' %}",
         showNoSuggestionNotice: true,
         dataType: 'json',
         paramName: 'term',
@@ -52,6 +52,10 @@ $(document).ready(function() {
         onSelect: function (suggestion) {
             window.location.href = '/exercise/' + suggestion.data.id + '/view/'
         }
+    });
+    // show specific body parts on hovering
+    $('ul').find('a').hover(function() {
+        $(this).tab('show');
     });
 });
 </script>
@@ -67,8 +71,8 @@ $(document).ready(function() {
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
-    <li {% if forloop.first %}class="active"{% endif %}>
-        <a href="#tab-{{ item.grouper.id }}" id="category-{{ item.grouper.id }}" data-toggle="tab">{% trans item.grouper.name %}</a>
+    <li  class="{% if forloop.first %} active {% endif %}" >
+        <a href="#tab-{{ item.grouper.id }}" id="category-{{ item.grouper.id }}" data-toggle="tab" class="body-part-tab">{% trans item.grouper.name %}</a>
     </li>
     {% empty %}
         <li>{% trans "No categories." %} {% trans "Use link to create one" %}</li>


### PR DESCRIPTION
**Problem**
Currently, a user is  unable to get exercises for a body part when the mouse hovers over the body part

**Solution**
Add a feature to enable users to get exercises for a body part when the mouse hovers over the tabs

**Screen Capture**
![get-exercises-on-mouse-hover](https://user-images.githubusercontent.com/37342753/44134726-d2a8629c-a06e-11e8-8bc7-54654ccb9a2b.gif)

[Pivotal Tracker Card](https://www.pivotaltracker.com/story/show/159356773)