### PR TITLE
[FT:] Add cache for nutrition plans

### DIFF
--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,21 @@
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from django.core.cache import cache
+
+from wger.nutrition.models import NutritionPlan
+
+
+@receiver(post_delete, sender=NutritionPlan)
+def reset_cache_nutrition_plan_on_delete(sender, instance, **kwargs):
+    '''
+    Resets the nutrition plan cache on delete.
+    '''
+    cache.clear()
+
+@receiver(post_save, sender=NutritionPlan)
+def reset_cache_nutrition_plan_on_save(sender, instance, **kwargs):
+    '''
+    Resets the nutrition plan cache on save.
+    '''
+    cache.clear()
+    

--- a/wger/nutrition/templates/plan/overview.html
+++ b/wger/nutrition/templates/plan/overview.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% load i18n %}
-{% load staticfiles %}
+{% load i18n staticfiles cache wger_extras %}
 
 {% block title %}{% trans "Your nutrition plans" %}{% endblock %}
 
 
 {% block content %}
+{% cache 30 pan-overview language.id %}
 <div class="list-group">
     {% for plan in plans %}
         <a href="{{ plan.get_absolute_url }}" class="list-group-item">
@@ -16,7 +16,7 @@
                 {{ plan.creation_date }} –
                 {{ plan.get_nutritional_values.total.energy|floatformat }} {% trans "kcal" %}
             </p>
-        </a>
+        </a> 
     {% empty %}
         <a href="{% url 'nutrition:plan:add' %}" class="list-group-item">
         {% trans "No nutrition plans." %}<br>
@@ -24,6 +24,7 @@
         </a>
     {% endfor %}
 </div>
+{% endcache %}
 {% endblock %}
 
 

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -49,6 +49,7 @@ from wger.utils.generic_views import WgerFormMixin, WgerDeleteMixin
 from wger.utils.helpers import check_token, make_token
 from wger.utils.pdf import styleSheet
 from wger.utils.language import load_language
+from django.core.cache import cache
 
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ class PlanDeleteView(WgerDeleteMixin, DeleteView):
         '''
         Send some additional data to the template
         '''
+        cache.clear()
         context = super(PlanDeleteView, self).get_context_data(**kwargs)
         context['title'] = _(u'Delete {0}?').format(self.object)
         return context
@@ -117,6 +119,7 @@ class PlanEditView(WgerFormMixin, UpdateView):
         '''
         Send some additional data to the template
         '''
+        cache.clear()
         context = super(PlanEditView, self).get_context_data(**kwargs)
         context['title'] = _(u'Edit {0}').format(self.object)
         return context

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -81,7 +81,7 @@ def add(request):
     plan.user = request.user
     plan.language = load_language()
     plan.save()
-
+    cache.clear()
     return HttpResponseRedirect(reverse('nutrition:plan:view', kwargs={'id': plan.id}))
 
 


### PR DESCRIPTION
**Problem**
If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. 

**Solution**
Created cache for the NutritionPlans and added signals that delete the cache everytime a NutritionPlan added or deleted.